### PR TITLE
ci: replace AWS static credentials with OIDC role assumption

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,17 @@ jobs:
       run: |
         pdm install -G dev
         
+    - name: Configure aws credentials
+      env:
+        AWS_IAM_ROLE: ${{ vars.AWS_IAM_ROLE }}
+        AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ vars.AWS_IAM_ROLE }}
+        aws-region: ${{ vars.AWS_DEFAULT_REGION }}
     - name: Test, format, lint
       env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         DBHUB_API_KEY: ${{ secrets.DBHUB_API_KEY }}
         CODE_OCEAN_API_TOKEN: ${{ secrets.CODE_OCEAN_API_TOKEN }}
         CODE_OCEAN_DOMAIN: ${{ secrets.CODE_OCEAN_DOMAIN }}


### PR DESCRIPTION
Replaces `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` static credential env vars with `aws-actions/configure-aws-credentials@v6` action using IAM role assumption via OIDC.
